### PR TITLE
Help from timing out in game.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -182,7 +182,7 @@ impl Client {
 
     pub async fn send_server_sync(&self) -> Result<(), MumbleError> {
         let mut server_sync = ServerSync::default();
-        server_sync.set_max_bandwidth(144000);
+        server_sync.set_max_bandwidth(72000);
         server_sync.set_session(self.session_id);
         server_sync.set_welcome_text("ZUMBLE Server".to_string());
 
@@ -191,7 +191,7 @@ impl Client {
 
     pub async fn send_server_config(&self) -> Result<(), MumbleError> {
         let mut server_config = ServerConfig::default();
-        server_config.set_max_bandwidth(144000);
+        server_config.set_max_bandwidth(72000);
         server_config.set_max_users(2048);
         server_config.set_allow_html(true);
         server_config.set_message_length(512);

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -130,14 +130,14 @@ impl CryptState {
             if diff > 0 {
                 lost = i32::from(diff - 1); // lost a few packets in between this and the last one
             } else if diff > -30 {
-                if self.decrypt_history[nonce_0 as usize] == (self.decrypt_nonce >> 8) as u8 {
-                    self.decrypt_nonce = saved_nonce;
+                //if self.decrypt_history[nonce_0 as usize] == (self.decrypt_nonce >> 8) as u8 {
+                //    self.decrypt_nonce = saved_nonce;
 
-                    return Err(DecryptError::Repeat);
-                }
+                //    return Err(DecryptError::Repeat);
+                //}
                 // just late
-                late = true;
-                lost = -1;
+                //late = true;
+                //lost = -1;
             } else {
                 self.decrypt_nonce = saved_nonce;
                 return Err(DecryptError::Late); // late by more than 30 packets


### PR DESCRIPTION
When switching to external voice server, more connection timed out we have seen. I believe lowering the voice quality twice will help players bandwith but it won't have any negative impact for the voice quality.